### PR TITLE
🗺️ Bumped version to v0.0.0-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "transit-trail",
   "private": true,
-  "version": "0.0.0-1",
+  "version": "0.0.0-2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "transit_trail"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 dependencies = [
  "log",
  "markdown",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transit_trail"
-version = "0.0.0-alpha.1"
+version = "0.0.0-alpha.2"
 description = "Navigate Winnipeg Transit with a different style"
 authors = ["MaFeLP", "PrincessFoxx"]
 license = "GPLv3-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "transit-trail",
-    "version": "0.0.0-1"
+    "version": "0.0.0-2"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
This bumps the version to version `0.0.0-alpha.2`, to represent the addition of the trip planner